### PR TITLE
Unit tests for mongodb.py

### DIFF
--- a/tests/unit/test_mongodb_lib.py
+++ b/tests/unit/test_mongodb_lib.py
@@ -2,12 +2,11 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from pymongo.errors import ConfigurationError, ConnectionFailure, OperationFailure
-from tenacity import RetryError
 
-from lib.charms.mongodb_libs.v0.mongodb import MongoDBConfiguration, MongoDBConnection
+from lib.charms.mongodb_libs.v0.mongodb import MongoDBConnection, NotReadyError
 
 MONGO_CONFIG = {
     "replset": "mongo-k8s",
@@ -25,31 +24,177 @@ PYMONGO_EXCEPTIONS = [
 
 
 class TestMongoServer(unittest.TestCase):
-    # def mongodb_config(self) -> MongoDBConfiguration:
-    #     """TODO."""
-    #     return MongoDBConfiguration(
-    #         replset="mongo-k8s",
-    #         database="admin",
-    #         username="operator",
-    #         password="password",
-    #         hosts=set(["1.1.1.1", "2.2.2.2"])
-    #     )
-
     @patch("lib.charms.mongodb_libs.v0.mongodb.MongoClient")
     @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConfiguration")
     def test_is_ready_error_handling(self, config, mock_client):
-        """Test on failure to check ready of replica returns False.
+        """Test failure to check ready of replica returns False.
 
         Test also verifies that when an exception is raised we still close the client connection.
         """
-
-        for exception, expected_raise in PYMONGO_EXCEPTIONS:
+        for exception, _ in PYMONGO_EXCEPTIONS:
             with MongoDBConnection(config) as mongo:
-                mock_client.admin.command.side_effect = exception
+                mock_client.return_value.admin.command.side_effect = exception
 
                 #  verify ready is false when an error occurs
                 ready = mongo.is_ready
                 self.assertEqual(ready, False)
 
-                # verify we close connection
-                (mock_client.close).assert_called()
+            # verify we close connection
+            (mock_client.return_value.close).assert_called()
+
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoClient")
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConfiguration")
+    def test_init_replset_error_handling(self, config, mock_client):
+        """Test failure to initialise replica set raises an error.
+
+        Test also verifies that when an exception is raised we still close the client connection.
+        """
+        for exception, expected_raise in PYMONGO_EXCEPTIONS:
+            with self.assertRaises(expected_raise):
+                with MongoDBConnection(config) as mongo:
+                    mock_client.return_value.admin.command.side_effect = exception
+                    mongo.init_replset()
+
+            # verify we close connection
+            (mock_client.return_value.close).assert_called()
+
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoClient")
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConfiguration")
+    def test_get_replset_members_error_handling(self, config, mock_client):
+        """Test failure to get replica set members raises an error.
+
+        Test also verifies that when an exception is raised we still close the client connection.
+        """
+        for exception, expected_raise in PYMONGO_EXCEPTIONS:
+            with self.assertRaises(expected_raise):
+                with MongoDBConnection(config) as mongo:
+                    mock_client.return_value.admin.command.side_effect = exception
+                    mongo.get_replset_members()
+
+            # verify we close connection
+            (mock_client.return_value.close).assert_called()
+
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoClient")
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConfiguration")
+    def test_add_replset_members_pymongo_error_handling(self, config, mock_client):
+        """Test failures related to PyMongo properly get handled in add_replset_member.
+
+        Test also verifies that when an exception is raised we still close the client connection
+        and that no attempt to replSetReconfig is made.
+        """
+        for exception, expected_raise in PYMONGO_EXCEPTIONS:
+            with self.assertRaises(expected_raise):
+                with MongoDBConnection(config) as mongo:
+                    mock_client.return_value.admin.command.side_effect = exception
+                    mongo.add_replset_member("hostname")
+
+            # verify we close connection
+            (mock_client.return_value.close).assert_called()
+
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConnection._is_any_sync")
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoClient")
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConfiguration")
+    def test_add_replset_member_wait_to_sync(self, config, mock_client, any_sync):
+        """Tests that adding replica set members raises NotReadyError if another member is syncing.
+
+        Test also verifies that when an exception is raised we still close the client connection
+        and that no attempt to replSetReconfig is made.
+        """
+        any_sync.return_value = True
+        with self.assertRaises(NotReadyError):
+            with MongoDBConnection(config) as mongo:
+                mongo.add_replset_member("hostname")
+
+        # verify we close connection and that no attempt to reconfigure was made
+        (mock_client.return_value.close).assert_called()
+
+        actual_calls = mock_client.return_value.admin.command.mock_calls
+        no_reconfig = call("replSetReconfig") not in actual_calls
+        self.assertEqual(no_reconfig, True)
+
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoClient")
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConfiguration")
+    def test_remove_replset_members_pymongo_error_handling(self, config, mock_client):
+        """Test failures related to PyMongo properly get handled in remove_replset_member.
+
+        Test also verifies that when an exception is raised we still close the client connection
+        and that no attempt to replSetReconfig is made.
+        """
+        for exception, expected_raise in PYMONGO_EXCEPTIONS:
+            with self.assertRaises(expected_raise):
+                with MongoDBConnection(config) as mongo:
+                    mock_client.return_value.admin.command.side_effect = exception
+                    mongo.remove_replset_member("hostname")
+
+            # verify we close connection
+            (mock_client.return_value.close).assert_called()
+
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConnection._is_any_removing")
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoClient")
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConfiguration")
+    def test_remove_replset_member_wait_to_remove(self, config, mock_client, any_remove):
+        """Tests removing replica set members raises NotReadyError if another member is removing.
+
+        Test also verifies that when an exception is raised we still close the client connection
+        and that no attempt to replSetReconfig is made.
+        """
+        any_remove.return_value = True
+        with self.assertRaises(NotReadyError):
+            with MongoDBConnection(config) as mongo:
+                mongo.remove_replset_member("hostname")
+
+        # verify we close connection and that no attempt to reconfigure was made
+        (mock_client.return_value.close).assert_called()
+
+        actual_calls = mock_client.return_value.admin.command.mock_calls
+        no_reconfig = call("replSetReconfig") not in actual_calls
+        self.assertEqual(no_reconfig, True)
+
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConnection._is_any_removing")
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoClient")
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConfiguration")
+    def test_create_user_error_handling(self, config, mock_client, any_remove):
+        """Test failures related to PyMongo properly get handled when creating a user.
+
+        Test also verifies that when an exception is raised we still close the client connection.
+        """
+        for exception, expected_raise in PYMONGO_EXCEPTIONS:
+            with self.assertRaises(expected_raise):
+                with MongoDBConnection(config) as mongo:
+                    mock_client.return_value.admin.command.side_effect = exception
+                    mongo.create_user(config)
+
+            # verify we close connection
+            (mock_client.return_value.close).assert_called()
+
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoClient")
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConfiguration")
+    def test_update_user_error_handling(self, config, mock_client):
+        """Test failures related to PyMongo properly get handled when updating a user.
+
+        Test also verifies that when an exception is raised we still close the client connection.
+        """
+        for exception, expected_raise in PYMONGO_EXCEPTIONS:
+            with self.assertRaises(expected_raise):
+                with MongoDBConnection(config) as mongo:
+                    mock_client.return_value.admin.command.side_effect = exception
+                    mongo.update_user(config)
+
+            # verify we close connection
+            (mock_client.return_value.close).assert_called()
+
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoClient")
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConfiguration")
+    def test_drop_user_error_handling(self, config, mock_client):
+        """Test failures related to PyMongo properly get handled when dropping a user.
+
+        Test also verifies that when an exception is raised we still close the client connection.
+        """
+        for exception, expected_raise in PYMONGO_EXCEPTIONS:
+            with self.assertRaises(expected_raise):
+                with MongoDBConnection(config) as mongo:
+                    mock_client.return_value.admin.command.side_effect = exception
+                    mongo.drop_user("username")
+
+            # verify we close connection
+            (mock_client.return_value.close).assert_called()

--- a/tests/unit/test_mongodb_lib.py
+++ b/tests/unit/test_mongodb_lib.py
@@ -1,0 +1,55 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import patch
+
+from pymongo.errors import ConfigurationError, ConnectionFailure, OperationFailure
+from tenacity import RetryError
+
+from lib.charms.mongodb_libs.v0.mongodb import MongoDBConfiguration, MongoDBConnection
+
+MONGO_CONFIG = {
+    "replset": "mongo-k8s",
+    "database": "admin",
+    "username": "operator",
+    "password": "password",
+    "hosts": set(["1.1.1.1", "2.2.2.2"]),
+}
+
+PYMONGO_EXCEPTIONS = [
+    (ConnectionFailure("error message"), ConnectionFailure),
+    (ConfigurationError("error message"), ConfigurationError),
+    (OperationFailure("error message"), OperationFailure),
+]
+
+
+class TestMongoServer(unittest.TestCase):
+    # def mongodb_config(self) -> MongoDBConfiguration:
+    #     """TODO."""
+    #     return MongoDBConfiguration(
+    #         replset="mongo-k8s",
+    #         database="admin",
+    #         username="operator",
+    #         password="password",
+    #         hosts=set(["1.1.1.1", "2.2.2.2"])
+    #     )
+
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoClient")
+    @patch("lib.charms.mongodb_libs.v0.mongodb.MongoDBConfiguration")
+    def test_is_ready_error_handling(self, config, mock_client):
+        """Test on failure to check ready of replica returns False.
+
+        Test also verifies that when an exception is raised we still close the client connection.
+        """
+
+        for exception, expected_raise in PYMONGO_EXCEPTIONS:
+            with MongoDBConnection(config) as mongo:
+                mock_client.admin.command.side_effect = exception
+
+                #  verify ready is false when an error occurs
+                ready = mongo.is_ready
+                self.assertEqual(ready, False)
+
+                # verify we close connection
+                (mock_client.close).assert_called()


### PR DESCRIPTION
### Problem
<!-- What problem is this PR trying to solve? -->

This PR addresses the basic need for unit tests for the [mongodb lib code](https://github.com/delgod/mongodb-k8s-operator/blob/main/lib/charms/mongodb_libs/v0/mongodb.py). Specifically for the cases in which commands to `mongod` fail. 

### Solution
<!-- A summary of the solution addressing the above problem -->

What this PR is:
1. Tests to handle the cases in which commands to `mongod` fail due to PyMongo errors.
2. Tests to verify operations when `NotReadyErrors` occur

What this PR is not:
1. Unit tests for `src/charm.py`
3. Unit tests for `lib/charms/mongodb_libs/v0/helpers.py`
4. Unit tests for `lib/charms/mongodb_libs/v0/mongodb_provider.py`

