### PR TITLE
Unit tests for charm.py

### DIFF
--- a/lib/charms/mongodb_libs/v0/mongodb.py
+++ b/lib/charms/mongodb_libs/v0/mongodb.py
@@ -181,7 +181,6 @@ class MongoDBConnection:
                 logger.error("Cannot initialize replica set. error=%r", e)
                 raise e
 
-    @property
     def get_replset_members(self) -> Set[str]:
         """Get a replica set members.
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -165,7 +165,7 @@ class MongoDBCharm(CharmBase):
 
         with MongoDBConnection(self.mongodb_config) as mongo:
             try:
-                replset_members = mongo.get_replset_members
+                replset_members = mongo.get_replset_members()
 
                 # compare set of mongod replica set members and juju hosts
                 # to avoid the unnecessary reconfiguration.

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from pathlib import Path
+from typing import Callable
+from unittest.mock import patch
+
+import yaml
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+
+def patch_network_get(private_address="10.1.157.116") -> Callable:
+    def network_get(*args, **kwargs) -> dict:
+        """Patch for the not-yet-implemented testing backend needed for `bind_address`.
+
+        This patch decorator can be used for cases such as:
+        self.model.get_binding(event.relation).network.bind_address
+        """
+        return {
+            "bind-addresses": [
+                {
+                    "addresses": [{"value": private_address}],
+                }
+            ]
+        }
+
+    return patch("ops.testing._TestingModelBackend.network_get", network_get)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,56 +2,80 @@
 # See LICENSE file for licensing details.
 
 import pytest
-from ops.model import ActiveStatus
+from ops.model import ActiveStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import MongoDBCharm
+from tests.unit.helpers import patch_network_get
+from unittest.mock import patch
+import unittest
 
 
-@pytest.fixture
-def harness():
-    harness = Harness(MongoDBCharm)
-    mongo_resource = {
-        "registrypath": "mongo:4.4",
-    }
-    harness.add_oci_resource("mongodb-image", mongo_resource)
-    harness.begin()
-    harness.add_relation("database-peers", "mongodb-peers")
-    harness.set_leader(True)
-    yield harness
-    harness.cleanup()
+class TestCharm(unittest.TestCase):
+    @patch_network_get(private_address="1.1.1.1")
+    def setUp(self):
+        self.harness = Harness(MongoDBCharm)
+        mongo_resource = {
+            "registrypath": "mongo:4.4",
+        }
+        self.harness.add_oci_resource("mongodb-image", mongo_resource)
+        self.harness.begin()
+        self.harness.add_relation("database-peers", "mongodb-peers")
+        self.harness.set_leader(True)
+        self.charm = self.harness.charm
+        self.addCleanup(self.harness.cleanup)
 
+    def test_mongod_pebble_ready(self):
+        # Expected plan after Pebble ready with default config
+        expected_plan = {
+            "services": {
+                "mongod": {
+                    "user": "mongodb",
+                    "group": "mongodb",
+                    "override": "replace",
+                    "summary": "mongod",
+                    "command": (
+                        "mongod --bind_ip_all --auth "
+                        "--replSet=mongodb-k8s "
+                        "--clusterAuthMode=keyFile "
+                        "--keyFile=/etc/mongodb/keyFile"
+                    ),
+                    "startup": "enabled",
+                }
+            },
+        }
+        # Get the mongod container from the model
+        container = self.harness.model.unit.get_container("mongod")
+        self.harness.set_can_connect(container, True)
+        # Emit the PebbleReadyEvent carrying the mongod container
+        self.harness.charm.on.mongod_pebble_ready.emit(container)
+        # Get the plan now we've run PebbleReady
+        updated_plan = self.harness.get_container_pebble_plan("mongod").to_dict()
+        # Check we've got the plan we expected
+        assert expected_plan == updated_plan
+        # Check the service was started
+        service = self.harness.model.unit.get_container("mongod").get_service("mongod")
+        assert service.is_running()
+        # Ensure we set an ActiveStatus with no message
+        assert self.harness.model.unit.status == ActiveStatus()
 
-def test_mongod_pebble_ready(harness):
-    # Expected plan after Pebble ready with default config
-    expected_plan = {
-        "services": {
-            "mongod": {
-                "user": "mongodb",
-                "group": "mongodb",
-                "override": "replace",
-                "summary": "mongod",
-                "command": (
-                    "mongod --bind_ip_all --auth "
-                    "--replSet=mongodb-k8s "
-                    "--clusterAuthMode=keyFile "
-                    "--keyFile=/etc/mongodb/keyFile"
-                ),
-                "startup": "enabled",
-            }
-        },
-    }
-    # Get the mongod container from the model
-    container = harness.model.unit.get_container("mongod")
-    harness.set_can_connect(container, True)
-    # Emit the PebbleReadyEvent carrying the mongod container
-    harness.charm.on.mongod_pebble_ready.emit(container)
-    # Get the plan now we've run PebbleReady
-    updated_plan = harness.get_container_pebble_plan("mongod").to_dict()
-    # Check we've got the plan we expected
-    assert expected_plan == updated_plan
-    # Check the service was started
-    service = harness.model.unit.get_container("mongod").get_service("mongod")
-    assert service.is_running()
-    # Ensure we set an ActiveStatus with no message
-    assert harness.model.unit.status == ActiveStatus()
+    # @patch("lib.charms.mongodb_libs.v0.mongodb.MongoClient")
+    # def test_start_mongo_failure(self, mongodb_client):
+    #     """Test verifies operation of start hook when ready check fails."""
+    #
+    #     # presets
+    #     self.harness.set_leader(True)
+    #     container = harness.model.unit.get_container("mongod")
+    #     harness.set_can_connect(container, True)
+    #     harness.set_exists(container, True)
+    #
+    #     self.harness.charm.on.start.emit()
+    #
+    #     # failure is mongodb ready
+    #     mongodb_client.is_replica_ready.assert_called()
+    #
+    #     # mongodb_client.init_replset.assert_not_called()
+    #     # mongodb_client.init_user.assert_not_called()
+    #     # mongodb_client.oversee_users.assert_not_called()
+    #     #
+    #     # # verify app data

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,14 +1,23 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import pytest
-from ops.model import ActiveStatus, WaitingStatus
+import unittest
+from unittest import mock
+from unittest.mock import patch
+
+from ops.model import ActiveStatus, ModelError
+from ops.pebble import APIError, ExecError
 from ops.testing import Harness
+from pymongo.errors import ConfigurationError, ConnectionFailure, OperationFailure
 
 from charm import MongoDBCharm
 from tests.unit.helpers import patch_network_get
-from unittest.mock import patch
-import unittest
+
+PYMONGO_EXCEPTIONS = [
+    (ConnectionFailure("error message"), ConnectionFailure),
+    (ConfigurationError("error message"), ConfigurationError),
+    (OperationFailure("error message"), OperationFailure),
+]
 
 
 class TestCharm(unittest.TestCase):
@@ -59,23 +68,242 @@ class TestCharm(unittest.TestCase):
         # Ensure we set an ActiveStatus with no message
         assert self.harness.model.unit.status == ActiveStatus()
 
-    # @patch("lib.charms.mongodb_libs.v0.mongodb.MongoClient")
-    # def test_start_mongo_failure(self, mongodb_client):
-    #     """Test verifies operation of start hook when ready check fails."""
-    #
-    #     # presets
-    #     self.harness.set_leader(True)
-    #     container = harness.model.unit.get_container("mongod")
-    #     harness.set_can_connect(container, True)
-    #     harness.set_exists(container, True)
-    #
-    #     self.harness.charm.on.start.emit()
-    #
-    #     # failure is mongodb ready
-    #     mongodb_client.is_replica_ready.assert_called()
-    #
-    #     # mongodb_client.init_replset.assert_not_called()
-    #     # mongodb_client.init_user.assert_not_called()
-    #     # mongodb_client.oversee_users.assert_not_called()
-    #     #
-    #     # # verify app data
+    @patch("charm.MongoDBProvider")
+    @patch("charm.MongoDBCharm._init_user")
+    @patch("charm.MongoDBConnection")
+    def test_start_cannot_retrieve_container(self, connection, init_user, provider):
+        """Verifies that failures to get container result in a ModelError being raised.
+
+        Further this function verifies that on error no attempts to set up the replica set or
+        database users are made.
+        """
+        # presets
+        self.harness.set_leader(True)
+        mock_container = mock.Mock()
+        mock_container.side_effect = ModelError
+        self.harness.charm.unit.get_container = mock_container
+        with self.assertRaises(ModelError):
+            self.harness.charm.on.start.emit()
+
+            # when cannot retrieve a container we should not set up the replica set or handle users
+            connection.return_value.__enter__.return_value.init_replset.assert_not_called()
+            init_user.assert_not_called()
+            provider.return_value.oversee_users.assert_not_called()
+
+            # verify app data
+            self.assertEqual("db_initialised" in self.harness.charm.app_data, False)
+
+    @patch("charm.MongoDBProvider")
+    @patch("charm.MongoDBCharm._init_user")
+    @patch("charm.MongoDBConnection")
+    def test_start_container_cannot_connect(self, connection, init_user, provider):
+        """Tests inability to connect results in deferral.
+
+        Verifies that if connection is not possible, that there are no attempts to set up the
+        replica set or handle users.
+        """
+        # presets
+        self.harness.set_leader(True)
+        mock_container = mock.Mock()
+        mock_container.return_value.can_connect.return_value = False
+        self.harness.charm.unit.get_container = mock_container
+
+        self.harness.charm.on.start.emit()
+
+        # when cannot connect to container we should not set up the replica set or handle users
+        connection.return_value.__enter__.return_value.init_replset.assert_not_called()
+        init_user.assert_not_called()
+        provider.return_value.oversee_users.assert_not_called()
+
+        # verify app data
+        self.assertEqual("db_initialised" in self.harness.charm.app_data, False)
+
+    @patch("charm.MongoDBProvider")
+    @patch("charm.MongoDBCharm._init_user")
+    @patch("charm.MongoDBConnection")
+    def test_start_container_does_not_exist(self, connection, init_user, provider):
+        """Tests lack of existence of files on container results in deferral.
+
+        Verifies that if files do not exists, that there are no attempts to set up the replica set
+        or handle users.
+        """
+        # presets
+        self.harness.set_leader(True)
+        mock_container = mock.Mock()
+        mock_container.return_value.can_connect.return_value = True
+        mock_container.return_value.exists.return_value = False
+        self.harness.charm.unit.get_container = mock_container
+
+        self.harness.charm.on.start.emit()
+
+        # when container does not exist we should not set up the replica set or handle users
+        connection.return_value.__enter__.return_value.init_replset.assert_not_called()
+        init_user.assert_not_called()
+        provider.return_value.oversee_users.assert_not_called()
+
+        # verify app data
+        self.assertEqual("db_initialised" in self.harness.charm.app_data, False)
+
+    @patch("charm.MongoDBProvider")
+    @patch("charm.MongoDBCharm._init_user")
+    @patch("charm.MongoDBConnection")
+    def test_start_container_exists_fails(self, connection, init_user, provider):
+        """Tests failure in checking file existence on container raises an APIError.
+
+        Verifies that when checking container files raises an API Error, we raise that same error
+        and make no attempts to set up the replica set or handle users.
+        """
+        # presets
+        self.harness.set_leader(True)
+        mock_container = mock.Mock()
+        mock_container.return_value.can_connect.return_value = True
+        mock_container.return_value.exists.side_effect = APIError("body", 0, "status", "message")
+        self.harness.charm.unit.get_container = mock_container
+
+        with self.assertRaises(APIError):
+            self.harness.charm.on.start.emit()
+
+            # when container does not exist we should not set up the replica set or handle users
+            connection.return_value.__enter__.return_value.init_replset.assert_not_called()
+            init_user.assert_not_called()
+            provider.return_value.oversee_users.assert_not_called()
+
+            # verify app data
+            self.assertEqual("db_initialised" in self.harness.charm.app_data, False)
+
+    @patch("charm.MongoDBProvider")
+    @patch("charm.MongoDBCharm._init_user")
+    @patch("charm.MongoDBConnection")
+    def test_start_already_initialised(self, connection, init_user, provider):
+        """Tests that if the replica set has already been set up that we return.
+
+        Verifies that if the replica set is already set up that no attempts to set it up again are
+        made and that there are no attempts to set up users.
+        """
+        # presets
+        self.harness.set_leader(True)
+
+        mock_container = mock.Mock()
+        mock_container.return_value.can_connect.return_value = True
+        mock_container.return_value.exists.return_value = True
+        self.harness.charm.unit.get_container = mock_container
+
+        self.harness.charm.app_data["db_initialised"] = "True"
+
+        self.harness.charm.on.start.emit()
+
+        # when the database has already been initialised we should not set up the replica set or
+        # handle users
+        connection.return_value.__enter__.return_value.init_replset.assert_not_called()
+        init_user.assert_not_called()
+        provider.return_value.oversee_users.assert_not_called()
+
+    @patch("charm.MongoDBProvider")
+    @patch("charm.MongoDBCharm._init_user")
+    @patch("charm.MongoDBConnection")
+    def test_start_mongod_not_ready(self, connection, init_user, provider):
+        """Tests that if mongod is not ready that we defer and return.
+
+        Verifies that if mongod is not ready that no attempts to set up the replica set and set up
+        users are made.
+        """
+        # presets
+        self.harness.set_leader(True)
+
+        mock_container = mock.Mock()
+        mock_container.return_value.can_connect.return_value = True
+        mock_container.return_value.exists.return_value = True
+        self.harness.charm.unit.get_container = mock_container
+
+        connection.return_value.__enter__.return_value.is_ready = False
+
+        self.harness.charm.on.start.emit()
+
+        # when mongod is not ready we should not set up the replica set or handle users
+        connection.return_value.__enter__.return_value.init_replset.assert_not_called()
+        init_user.assert_not_called()
+        provider.return_value.oversee_users.assert_not_called()
+
+        # verify app data
+        self.assertEqual("db_initialised" in self.harness.charm.app_data, False)
+
+    @patch("charm.MongoDBProvider")
+    @patch("charm.MongoDBCharm._init_user")
+    @patch("charm.MongoDBConnection")
+    def test_start_mongod_error_initalising_replica_set(self, connection, init_user, provider):
+        """Tests that failure to initialise replica set is properly handled.
+
+        Verifies that when there is a failure to initialise replica set that no operations related
+        to setting up users are executed.
+        """
+        # presets
+        self.harness.set_leader(True)
+
+        mock_container = mock.Mock()
+        mock_container.return_value.can_connect.return_value = True
+        mock_container.return_value.exists.return_value = True
+        self.harness.charm.unit.get_container = mock_container
+        connection.return_value.__enter__.return_value.is_ready = True
+
+        for exception, expected_raise in PYMONGO_EXCEPTIONS:
+            connection.return_value.__enter__.return_value.init_replset.side_effect = exception
+            self.harness.charm.on.start.emit()
+
+            init_user.assert_not_called()
+            provider.return_value.oversee_users.assert_not_called()
+
+            # verify app data
+            self.assertEqual("db_initialised" in self.harness.charm.app_data, False)
+
+    @patch("charm.MongoDBProvider")
+    @patch("charm.MongoDBCharm._init_user")
+    @patch("charm.MongoDBConnection")
+    def test_start_mongod_error_initalising_user(self, connection, init_user, provider):
+        """Tests that failure to initialise users set is properly handled.
+
+        Verifies that when there is a failure to initialise users that overseeing users is not
+        called.
+        """
+        # presets
+        self.harness.set_leader(True)
+
+        mock_container = mock.Mock()
+        mock_container.return_value.can_connect.return_value = True
+        mock_container.return_value.exists.return_value = True
+        self.harness.charm.unit.get_container = mock_container
+        connection.return_value.__enter__.return_value.is_ready = True
+
+        init_user.side_effect = ExecError("command", 0, "stdout", "stderr")
+        self.harness.charm.on.start.emit()
+
+        provider.return_value.oversee_users.assert_not_called()
+
+        # verify app data
+        self.assertEqual("db_initialised" in self.harness.charm.app_data, False)
+
+    @patch("charm.MongoDBProvider")
+    @patch("charm.MongoDBCharm._init_user")
+    @patch("charm.MongoDBConnection")
+    def test_start_mongod_error_overseeing_users(self, connection, init_user, provider):
+        """Tests failures related to pymongo are properly handled when overseeing users.
+
+        Verifies that when there is a failure to oversee users that we defer and do not set the
+        data base to initialised.
+        """
+        # presets
+        self.harness.set_leader(True)
+
+        mock_container = mock.Mock()
+        mock_container.return_value.can_connect.return_value = True
+        mock_container.return_value.exists.return_value = True
+        self.harness.charm.unit.get_container = mock_container
+        connection.return_value.__enter__.return_value.is_ready = True
+
+        for exception, expected_raise in PYMONGO_EXCEPTIONS:
+            provider.side_effect = exception
+            self.harness.charm.on.start.emit()
+
+            provider.return_value.oversee_users.assert_not_called()
+
+            # verify app data
+            self.assertEqual("db_initialised" in self.harness.charm.app_data, False)


### PR DESCRIPTION
### Problem
<!-- What problem is this PR trying to solve? -->

This PR addresses the basic need for unit tests for `charm.py`

### Solution
<!-- A summary of the solution addressing the above problem -->

This PR tests _all scenarios which are not tested in the integration tests for_ `charm.py`. 
- Tests failures which are caught
- Tests failures which aren't caught and result in raised exceptions
- Tests scenarios in which a deferral is necessary


