### PR TITLE
Resolving Bug for failure to reset TLS keys

### DIFF
--- a/lib/charms/mongodb_libs/v0/mongodb_tls.py
+++ b/lib/charms/mongodb_libs/v0/mongodb_tls.py
@@ -154,7 +154,7 @@ class MongoDBTLS(Object):
         old_cert = self.charm.get_secret(scope, "cert")
         renewal = old_cert and old_cert != event.certificate
 
-        if scope == "unit" or (scope == "app" and self.charm.unit.is_leader):
+        if scope == "unit" or (scope == "app" and self.charm.unit.is_leader()):
             self.charm.set_secret(
                 scope, "chain", "\n".join(event.chain) if event.chain is not None else None
             )

--- a/lib/charms/mongodb_libs/v0/mongodb_tls.py
+++ b/lib/charms/mongodb_libs/v0/mongodb_tls.py
@@ -146,8 +146,6 @@ class MongoDBTLS(Object):
             == self.charm.get_secret("app", "csr").rstrip()
         ):
             logger.debug("The internal TLS certificate available.")
-            if not self.charm.unit.is_leader():
-                return
             scope = "app"  # internal crs
         else:
             logger.error("An unknown certificate available.")

--- a/lib/charms/mongodb_libs/v0/mongodb_tls.py
+++ b/lib/charms/mongodb_libs/v0/mongodb_tls.py
@@ -154,11 +154,12 @@ class MongoDBTLS(Object):
         old_cert = self.charm.get_secret(scope, "cert")
         renewal = old_cert and old_cert != event.certificate
 
-        self.charm.set_secret(
-            scope, "chain", "\n".join(event.chain) if event.chain is not None else None
-        )
-        self.charm.set_secret(scope, "cert", event.certificate)
-        self.charm.set_secret(scope, "ca", event.ca)
+        if scope == "unit" or (scope == "app" and self.charm.unit.is_leader):
+            self.charm.set_secret(
+                scope, "chain", "\n".join(event.chain) if event.chain is not None else None
+            )
+            self.charm.set_secret(scope, "cert", event.certificate)
+            self.charm.set_secret(scope, "ca", event.ca)
 
         if renewal:
             self.charm.unit.get_container("mongod").stop("mongod")


### PR DESCRIPTION
### Problem
<!-- What problem is this PR trying to solve? -->
Setting the TLS private internal key was flakey. It would fail with _both_ auto generated private internal keys and provided internal keys

### Solution
<!-- A summary of the solution addressing the above problem --> The bug was caused by [this line](https://github.com/canonical/mongodb-operator/blob/2824c0eab45e0dd9ab2585f1c3d19aa947d14a9a/lib/charms/mongodb_libs/v0/mongodb_tls.py#L163-L164), no matter the status of a unit leader/non-leader, internal certificates should be updated (ie saved to the machine and mongod should be restarted with the new private key.)

To understand why this leads to flakey tests consider these two scenarios:
1. Working case: the app cert data gets updated with the internal cert before the (non-leader) unit receives an `_on_certificate_available` event , then it restarts with both internal and external certs
2. Broken case: the app cert data does NOT get updated with the internal cert before the (non-leader) unit receives an `_on_certificate_available` event , then it restarts with only the external certs. When it receives a second `_on_certificate_available` with the app cert it skips because of the return and doesn't have the correct internal cert.

### Release Notes
<!-- A digestable summary of the change in this PR -->
1. Removed bug causing line